### PR TITLE
feat: 제품 id로 이벤트 응모 신청 내역 조회 API 추가

### DIFF
--- a/src/main/java/rastle/dev/rastle_backend/domain/admin/api/AdminController.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/admin/api/AdminController.java
@@ -22,6 +22,7 @@ import rastle.dev.rastle_backend.domain.category.dto.CategoryInfo;
 import rastle.dev.rastle_backend.domain.event.dto.EventDTO.EventCreateRequest;
 import rastle.dev.rastle_backend.domain.event.dto.EventDTO.EventUpdateRequest;
 import rastle.dev.rastle_backend.domain.event.dto.EventInfo;
+import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.ProductEventApplyHistoryDTO;
 import rastle.dev.rastle_backend.domain.bundle.dto.BundleDTO.BundleCreateRequest;
 import rastle.dev.rastle_backend.domain.bundle.dto.BundleInfo;
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.MemberInfoDto;
@@ -122,7 +123,8 @@ public class AdminController {
         @GetExecutionTime
         @PostMapping("/product/{id}/detailImages")
         public ResponseEntity<ServerResponse<?>> uploadDetailImages(@PathVariable("id") Long id,
-                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "등록할 상품 이미지들") @RequestParam("detailImages") List<MultipartFile> detailImages) throws JsonProcessingException {
+                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "등록할 상품 이미지들") @RequestParam("detailImages") List<MultipartFile> detailImages)
+                        throws JsonProcessingException {
                 return ResponseEntity.ok(new ServerResponse<>(adminService.uploadDetailImages(id, detailImages)));
         }
 
@@ -133,7 +135,8 @@ public class AdminController {
         @PatchMapping("/product/{id}")
         public ResponseEntity<ServerResponse<?>> updateProductInfo(@PathVariable("id") Long id,
 
-                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "가계부 업데이트 요청", content = @Content(schema = @Schema(implementation = ProductUpdateRequest.class))) @RequestBody Map<String, Object> updateMap) throws JsonProcessingException {
+                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "가계부 업데이트 요청", content = @Content(schema = @Schema(implementation = ProductUpdateRequest.class))) @RequestBody Map<String, Object> updateMap)
+                        throws JsonProcessingException {
 
                 ProductUpdateRequest productUpdateRequest = objectMapper.convertValue(updateMap,
                                 ProductUpdateRequest.class);
@@ -177,7 +180,8 @@ public class AdminController {
         @GetExecutionTime
         @PutMapping("/product/{id}/detailImages")
         public ResponseEntity<ServerResponse<?>> updateDetailImages(@PathVariable("id") Long id,
-                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "업데이트할 상품 이미지들") @RequestParam("detailImages") List<MultipartFile> detailImages) throws JsonProcessingException {
+                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "업데이트할 상품 이미지들") @RequestParam("detailImages") List<MultipartFile> detailImages)
+                        throws JsonProcessingException {
                 return ResponseEntity.ok(new ServerResponse<>(adminService.updateDetailImages(id, detailImages)));
         }
 
@@ -185,7 +189,8 @@ public class AdminController {
         @FailApiResponses
         @GetExecutionTime
         @DeleteMapping("/product/{id}")
-        public ResponseEntity<ServerResponse<?>> deleteProduct(@PathVariable("id") Long id) throws JsonProcessingException {
+        public ResponseEntity<ServerResponse<?>> deleteProduct(@PathVariable("id") Long id)
+                        throws JsonProcessingException {
                 return ResponseEntity.ok(new ServerResponse<>(adminService.deleteProduct(id)));
         }
 
@@ -263,6 +268,18 @@ public class AdminController {
                 return ResponseEntity.ok(new ServerResponse<>(adminService.deleteEvent(id)));
         }
 
+        @Operation(summary = "제품 이벤트 응모 신청 내역 조회 API", description = "해당 제품이 받은 이벤트 응모 신청 내역을 조회합니다.")
+        @ApiResponse(responseCode = "200", description = "조회 성공시", content = @Content(schema = @Schema(implementation = ProductEventApplyHistoryDTO.class)))
+        @FailApiResponses
+        @GetMapping("/event/apply/{productId}")
+        public ResponseEntity<ServerResponse<?>> getProductEventApplyHistoryDTOs(
+                        @PathVariable("productId") Long productId,
+                        Pageable pageable) {
+                return ResponseEntity
+                                .ok(new ServerResponse<>(
+                                                adminService.getProductEventApplyHistoryDTOs(productId, pageable)));
+        }
+
         // ==============================================================================================================
         // 상품 세트 관련 API
         // ==============================================================================================================
@@ -329,11 +346,9 @@ public class AdminController {
                 return ResponseEntity.ok(adminService.getMemberByEmail(email));
         }
 
-
         // ==============================================================================================================
         // 주문 관련 API
         // ==============================================================================================================
-
 
         // ==============================================================================================================
         // 결제 관련 API

--- a/src/main/java/rastle/dev/rastle_backend/domain/admin/application/AdminService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/admin/application/AdminService.java
@@ -23,7 +23,9 @@ import rastle.dev.rastle_backend.domain.category.repository.mysql.CategoryReposi
 import rastle.dev.rastle_backend.domain.event.dto.EventDTO.EventCreateRequest;
 import rastle.dev.rastle_backend.domain.event.dto.EventDTO.EventUpdateRequest;
 import rastle.dev.rastle_backend.domain.event.dto.EventInfo;
+import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.ProductEventApplyHistoryDTO;
 import rastle.dev.rastle_backend.domain.event.model.Event;
+import rastle.dev.rastle_backend.domain.event.repository.mysql.EventProductApplyRepository;
 import rastle.dev.rastle_backend.domain.event.repository.mysql.EventRepository;
 import rastle.dev.rastle_backend.domain.bundle.dto.BundleInfo;
 import rastle.dev.rastle_backend.domain.bundle.model.Bundle;
@@ -70,6 +72,7 @@ public class AdminService {
     private final ProductDetailRepository productDetailRepository;
     private final MemberRepository memberRepository;
     private final OrderDetailRepository orderDetailRepository;
+    private final EventProductApplyRepository eventProductApplyRepository;
 
     // ==============================================================================================================
     // 상품 관련 서비스
@@ -529,6 +532,16 @@ public class AdminService {
         }
         eventRepository.deleteById(id);
         return "DELETED";
+    }
+
+    /**
+     * 제품 이벤트 응모 신청 내역 조회
+     * 
+     * @param memberId
+     */
+    @Transactional(readOnly = true)
+    public Page<ProductEventApplyHistoryDTO> getProductEventApplyHistoryDTOs(Long productId, Pageable pageable) {
+        return eventProductApplyRepository.getProductEventApplyHistoryDTOs(productId, pageable);
     }
 
     // ==============================================================================================================

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/api/EventController.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/api/EventController.java
@@ -7,13 +7,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import rastle.dev.rastle_backend.domain.event.application.EventService;
 import rastle.dev.rastle_backend.domain.event.dto.EventInfo;
 import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO;
-import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.EventProductApplyInfoDTO;
+import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.MemberEventApplyHistoryDTO;
 import rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo;
 import rastle.dev.rastle_backend.global.response.FailApiResponses;
 import rastle.dev.rastle_backend.global.response.ServerResponse;
@@ -57,12 +58,13 @@ public class EventController {
         return ResponseEntity.ok(new ServerResponse<>("이벤트 응모 신청이 완료되었습니다."));
     }
 
-    @Operation(summary = "이벤트 응모 신청 내역 조회 API", description = "이벤트 응모 신청 내역을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "조회 성공시", content = @Content(schema = @Schema(implementation = EventProductApplyInfoDTO.class)))
+    @Operation(summary = "회원 이벤트 응모 신청 내역 조회 API", description = "회원의 이벤트 응모 신청 내역을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공시", content = @Content(schema = @Schema(implementation = MemberEventApplyHistoryDTO.class)))
     @FailApiResponses
     @GetMapping("/apply")
-    public ResponseEntity<ServerResponse<?>> getEventProductApplyInfoDTOs() {
+    public ResponseEntity<ServerResponse<?>> getMemberEventApplyHistoryDTOs(Pageable pageable) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        return ResponseEntity.ok(new ServerResponse<>(eventService.getEventProductApplyInfoDTOs(currentMemberId)));
+        return ResponseEntity
+                .ok(new ServerResponse<>(eventService.getMemberEventApplyHistoryDTOs(currentMemberId, pageable)));
     }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/dto/EventProductApplyDTO.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/dto/EventProductApplyDTO.java
@@ -25,10 +25,30 @@ public class EventProductApplyDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Schema(description = "이벤트 응모 내역 정보 DTO")
-    public static class EventProductApplyInfoDTO {
+    @Schema(description = "회원 이벤트 응모 내역 정보 DTO")
+    public static class MemberEventApplyHistoryDTO {
+        @Schema(description = "이벤트 응모 상품 아이디", type = "Long", format = "eventProductId", example = "1")
+        private Long eventProductId;
         @Schema(description = "이벤트 응모 제품명", type = "string", format = "name", example = "청바지")
         private String eventProductName;
+        @Schema(description = "이벤트 응모 제품 썸네일 이미지", type = "string", format = "mainThumbnailImage", example = "https://aws.~~~~")
+        private String eventProductMainThumbnailImage;
+        @Schema(description = "이벤트 응모 날짜", type = "LocalDateTime", format = "applyDate", example = "2021-08-01T00:00:00")
+        private LocalDateTime eventApplyDate;
+        @Schema(description = "이벤트 응모 인스타그램 아이디", type = "string", format = "instagramId", example = "rastle_fashion")
+        private String instagramId;
+        @Schema(description = "이벤트 응모 전화번호", type = "string", format = "phoneNumber", example = "01012345678")
+        private String eventPhoneNumber;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "제품 이벤트 응모 내역 정보 DTO")
+    public static class ProductEventApplyHistoryDTO {
+        @Schema(description = "회원 이름", type = "string", format = "name", example = "홍길동")
+        private String memberName;
         @Schema(description = "이벤트 응모 날짜", type = "LocalDateTime", format = "applyDate", example = "2021-08-01T00:00:00")
         private LocalDateTime eventApplyDate;
         @Schema(description = "이벤트 응모 인스타그램 아이디", type = "string", format = "instagramId", example = "rastle_fashion")

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/exception/handler/EventExceptionHandler.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/exception/handler/EventExceptionHandler.java
@@ -1,4 +1,9 @@
 package rastle.dev.rastle_backend.domain.event.exception.handler;
 
 public class EventExceptionHandler {
+    public static class NotEventProductException extends RuntimeException {
+        public NotEventProductException() {
+            super("해당 상품은 이벤트 상품이 아닙니다.");
+        }
+    }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/model/Event.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/model/Event.java
@@ -29,9 +29,6 @@ public class Event {
     private LocalDateTime eventEndDate;
     private String description;
     private boolean visible;
-    // 응모자 수
-    @Column(name = "apply_count")
-    private Long applyCount;
 
     @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<ProductBase> eventProducts = new ArrayList<>();

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/model/EventProductApply.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/model/EventProductApply.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +32,7 @@ public class EventProductApply {
     @Column(name = "apply_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -45,7 +46,7 @@ public class EventProductApply {
     @Column(name = "apply_date", updatable = false)
     private LocalDateTime applyDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private ProductBase eventApplyProduct;
 

--- a/src/main/java/rastle/dev/rastle_backend/domain/event/repository/mysql/EventProductApplyRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/event/repository/mysql/EventProductApplyRepository.java
@@ -1,19 +1,34 @@
 package rastle.dev.rastle_backend.domain.event.repository.mysql;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.EventProductApplyInfoDTO;
+import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.MemberEventApplyHistoryDTO;
+import rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO.ProductEventApplyHistoryDTO;
 import rastle.dev.rastle_backend.domain.event.model.EventProductApply;
 
 public interface EventProductApplyRepository extends JpaRepository<EventProductApply, Long> {
-    @Query("SELECT new rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO$EventProductApplyInfoDTO(" +
-            "pb.name, epa.applyDate, epa.instagramId, epa.phoneNumber) " +
-            "FROM EventProductApply epa " +
-            "JOIN epa.eventApplyProduct pb " +
-            "WHERE epa.member.id = :memberId")
-    List<EventProductApplyInfoDTO> getEventProductApplyInfoDTOs(@Param("memberId") Long memberId);
+        // 회원 이벤트 응모 내역 조회
+        @Query("SELECT new rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO$MemberEventApplyHistoryDTO("
+                        +
+                        "pb.id, pb.name, pb.mainThumbnailImage, epa.applyDate, epa.instagramId, epa.phoneNumber) " +
+                        "FROM EventProductApply epa " +
+                        "JOIN epa.eventApplyProduct pb " +
+                        "WHERE epa.member.id = :memberId")
+        Page<MemberEventApplyHistoryDTO> getMemberEventApplyHistoryDTOs(@Param("memberId") Long memberId,
+                        Pageable pageable);
+
+        // 제품 이벤트 응모 내역 조회
+        @Query("SELECT new rastle.dev.rastle_backend.domain.event.dto.EventProductApplyDTO$ProductEventApplyHistoryDTO("
+                        +
+                        "m.userName, epa.applyDate, epa.instagramId, epa.phoneNumber) " +
+                        "FROM EventProductApply epa " +
+                        "JOIN epa.member m " +
+                        "WHERE epa.eventApplyProduct.id = :productId")
+        Page<ProductEventApplyHistoryDTO> getProductEventApplyHistoryDTOs(@Param("productId") Long productId,
+                        Pageable pageable);
+
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/product/dto/SimpleProductInfo.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/product/dto/SimpleProductInfo.java
@@ -34,4 +34,6 @@ public class SimpleProductInfo {
     Long bundleId;
     @Schema(description = "상품 이벤트 아이디", defaultValue = "1")
     Long eventId;
+    @Schema(description = "상품 이벤트 참여 횟수", defaultValue = "1")
+    Long eventApplyCount;
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/product/model/ProductBase.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/product/model/ProductBase.java
@@ -51,20 +51,23 @@ public class ProductBase {
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<CartProduct> cartProducts = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bundle_id")
     private Bundle bundle;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 
     @OneToMany(mappedBy = "eventApplyProduct", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<EventProductApply> eventProductApplies = new ArrayList<>();
+
+    @Column(name = "event_apply_count")
+    private Long eventApplyCount;
 
     @Builder
     public ProductBase(Long id, String name, int price, String mainThumbnailImage, String subThumbnailImage,
@@ -124,5 +127,10 @@ public class ProductBase {
 
     public void setEvent(Event event) {
         this.event = event;
+    }
+
+    @PrePersist
+    public void incrementEventApplyCount() {
+        this.eventApplyCount++;
     }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/product/repository/mysql/ProductBaseRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/product/repository/mysql/ProductBaseRepository.java
@@ -13,100 +13,102 @@ import java.util.Optional;
 
 public interface ProductBaseRepository extends JpaRepository<ProductBase, Long> {
 
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id) " +
-            "from ProductBase pb WHERE pb.event.id = null ORDER BY pb.displayOrder ASC")
-    Page<SimpleProductInfo> getProductInfos(Pageable pageable);
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id) " +
-            "from ProductBase pb WHERE pb.visible = :visible AND pb.event.id = null ORDER BY pb.displayOrder ASC")
-    Page<SimpleProductInfo> getProductInfosByVisibility(@Param("visible") boolean visible, Pageable pageable);
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id) " +
+                        "from ProductBase pb WHERE pb.event.id = null ORDER BY pb.displayOrder ASC")
+        Page<SimpleProductInfo> getProductInfos(Pageable pageable);
 
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.ProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id, " +
-            "pd.productMainImages, " +
-            "pd.productDetailImages, " +
-            "pd.productColors) " +
-            "FROM ProductBase pb  " +
-            "JOIN ProductDetail pd ON pb.productDetail.id = pd.id " +
-            "WHERE pb.id = :id")
-    Optional<ProductInfo> getProductDetailInfoById(@Param("id") Long id);
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id) " +
+                        "from ProductBase pb WHERE pb.visible = :visible AND pb.event.id = null ORDER BY pb.displayOrder ASC")
+        Page<SimpleProductInfo> getProductInfosByVisibility(@Param("visible") boolean visible, Pageable pageable);
 
-    boolean existsProductBaseByCategoryId(Long id);
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.ProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id, " +
+                        "pd.productMainImages, " +
+                        "pd.productDetailImages, " +
+                        "pd.productColors) " +
+                        "FROM ProductBase pb  " +
+                        "JOIN ProductDetail pd ON pb.productDetail.id = pd.id " +
+                        "WHERE pb.id = :id")
+        Optional<ProductInfo> getProductDetailInfoById(@Param("id") Long id);
 
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id) " +
-            "from ProductBase pb WHERE pb.event.id = :id ORDER BY pb.displayOrder DESC")
-    Page<SimpleProductInfo> getProductInfoByBundleId(@Param("id") Long id, Pageable pageable);
+        boolean existsProductBaseByCategoryId(Long id);
 
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id) " +
-            "from ProductBase pb WHERE pb.category.id = :id ORDER BY pb.displayOrder DESC")
-    Page<SimpleProductInfo> getProductInfoByCategoryId(@Param("id") Long id, Pageable pageable);
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id) " +
+                        "from ProductBase pb WHERE pb.event.id = :id ORDER BY pb.displayOrder DESC")
+        Page<SimpleProductInfo> getProductInfoByBundleId(@Param("id") Long id, Pageable pageable);
 
-    @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
-            "pb.id, " +
-            "pb.name, " +
-            "pb.price, " +
-            "pb.mainThumbnailImage, " +
-            "pb.subThumbnailImage," +
-            "pb.discountPrice, " +
-            "pb.displayOrder, " +
-            "pb.visible, " +
-            "pb.category.id, " +
-            "pb.bundle.id, " +
-            "pb.event.id) " +
-            "from ProductBase pb WHERE pb.event.id = :id ORDER BY pb.displayOrder DESC")
-    Page<SimpleProductInfo> getProductInfoByEventId(@Param("id") Long id, Pageable pageable);
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id) " +
+                        "from ProductBase pb WHERE pb.category.id = :id ORDER BY pb.displayOrder DESC")
+        Page<SimpleProductInfo> getProductInfoByCategoryId(@Param("id") Long id, Pageable pageable);
+
+        @Query("select new rastle.dev.rastle_backend.domain.product.dto.SimpleProductInfo(" +
+                        "pb.id, " +
+                        "pb.name, " +
+                        "pb.price, " +
+                        "pb.mainThumbnailImage, " +
+                        "pb.subThumbnailImage," +
+                        "pb.discountPrice, " +
+                        "pb.displayOrder, " +
+                        "pb.visible, " +
+                        "pb.category.id, " +
+                        "pb.bundle.id, " +
+                        "pb.event.id, " +
+                        "pb.eventApplyCount) " +
+                        "from ProductBase pb WHERE pb.event.id = :id ORDER BY pb.displayOrder DESC")
+        Page<SimpleProductInfo> getProductInfoByEventId(@Param("id") Long id, Pageable pageable);
 
 }


### PR DESCRIPTION
관리자 이벤트 기능에 제품 id로 이벤트 응모 신청 내역을 조회하는 API를 추가하였습니다.

이벤트에 속한 상품 조회 API 중 이벤트 상품의 참여자 수를 추가로 반환합니다.

회원 이벤트 응모 내역 조회 시 이벤트 응모 상품의 아이디와 메인 썸네일을 추가적으로 반환합니다.

Event 엔티티의 applyCount 필드를 삭제하고 productBase 엔티티에 eventProductApplyCount 필드를 추가하였습니다.

이벤트 응모 신청 로직 중 해당 상품의 이벤트 상품 여부를 확인하는 로직을 추가하였습니다. 이벤트 응모 신청 시 productBase의 eventProductApplyCount를 1 증가시키도록 하였습니다.

EventProductApply 엔티티의 Member, ProductBase와의 fetch 전략을 LAZY로 변경하였습니다. ProductBase 엔티티의 Bundle, Event, Category와의 fetch 전략을 LAZY로 변경하였습니다.