### PR TITLE
feat: 회원 주소지가 배송지 정보로 변경됨에 따른 코드 수정

### DIFF
--- a/src/main/java/rastle/dev/rastle_backend/domain/admin/application/AdminService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/admin/application/AdminService.java
@@ -573,10 +573,7 @@ public class AdminService {
                 .userLoginType(member.getUserLoginType())
                 .userName(member.getUserName())
                 .phoneNumber(member.getPhoneNumber())
-                // .address(String.format("%s %s %s", member.getZipCode(),
-                // member.getRoadAddress(),
-                // member.getDetailAddress()))
-                .address(member.getAddress().toString())
+                .recipientInfo(member.getRecipientInfo())
                 .createdDate(member.getCreatedDate())
                 .allOrderDetails(allOrderDetails)
                 .build();

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/api/MemberController.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/api/MemberController.java
@@ -17,7 +17,7 @@ import rastle.dev.rastle_backend.domain.member.application.MemberService;
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.LoginMemberInfoDto;
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.NewPhoneNumberDto;
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.PasswordDto;
-import rastle.dev.rastle_backend.domain.member.model.Address;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.global.response.FailApiResponses;
 import rastle.dev.rastle_backend.global.response.ServerResponse;
 import rastle.dev.rastle_backend.global.util.SecurityUtil;
@@ -61,25 +61,25 @@ public class MemberController {
         return ResponseEntity.ok(new ServerResponse<>("회원 탈퇴 성공"));
     }
 
-    @Operation(summary = "회원 주소지 갱신", description = "회원의 주소지를 갱신합니다.")
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "회원 주소지 갱신 성공"),
-            @ApiResponse(responseCode = "400", description = "회원 주소지 갱신 실패") })
-    @PutMapping("/updateMemberAddress")
-    public ResponseEntity<ServerResponse<String>> updateMemberAddress(HttpServletResponse response,
-            @RequestBody Address address) {
+    @Operation(summary = "회원 배송지 정보 갱신", description = "회원의 배송지 정보를 갱신합니다.")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "회원 배송지 갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "회원 배송지 갱신 실패") })
+    @PutMapping("/updateMemberRecipientInfo")
+    public ResponseEntity<ServerResponse<String>> updateMemberRecipientInfo(HttpServletResponse response,
+            @Valid @RequestBody RecipientInfo recipientInfo) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        memberService.updateMemberAddress(currentMemberId, address);
-        return ResponseEntity.ok(new ServerResponse<>("회원 주소지 갱신 성공"));
+        memberService.updateMemberRecipientInfo(currentMemberId, recipientInfo);
+        return ResponseEntity.ok(new ServerResponse<>("회원 배송지 갱신 성공"));
     }
 
-    @Operation(summary = "회원 주소지 조회", description = "회원의 주소지를 조회합니다.")
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "회원 주소지 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "회원 주소지 조회 실패") })
-    @GetMapping("/getMemberAddress")
-    public ResponseEntity<ServerResponse<Address>> getMemberAddress(HttpServletResponse response) {
+    @Operation(summary = "회원 배송지 정보 조회", description = "회원의 배송지 정보를 조회합니다.")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "회원 배송지 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "회원 배송지 조회 실패") })
+    @GetMapping("/getMemberRecipientInfo")
+    public ResponseEntity<ServerResponse<RecipientInfo>> getMemberRecipientInfo(HttpServletResponse response) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        Address address = memberService.getMemberAddress(currentMemberId);
-        ServerResponse<Address> serverResponse = new ServerResponse<>(address);
+        RecipientInfo recipientInfo = memberService.getMemberRecipientInfo(currentMemberId);
+        ServerResponse<RecipientInfo> serverResponse = new ServerResponse<>(recipientInfo);
         return ResponseEntity.ok(serverResponse);
     }
 

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberAuthService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberAuthService.java
@@ -24,6 +24,7 @@ import rastle.dev.rastle_backend.domain.coupon.repository.mysql.CouponRepository
 import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.LoginDto;
 import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.SignUpDto;
 import rastle.dev.rastle_backend.domain.member.model.Member;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.domain.member.repository.mysql.MemberRepository;
 import rastle.dev.rastle_backend.domain.token.dto.TokenDTO.TokenInfoDTO;
 import rastle.dev.rastle_backend.global.error.exception.InvalidRequestException;
@@ -56,6 +57,10 @@ public class MemberAuthService {
         }
         signUpDto.encode(passwordEncoder);
         Member entity = signUpDto.toEntity();
+        RecipientInfo recipientInfo = new RecipientInfo();
+        recipientInfo.setRecipientName(signUpDto.getUsername());
+        recipientInfo.setRecipientPhoneNumber(signUpDto.getPhoneNumber());
+        entity.updateRecipientInfo(recipientInfo);
         memberRepository.save(entity);
         Cart build = Cart.builder().member(entity).build();
         cartRepository.save(build);

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberService.java
@@ -11,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.LoginMemberInfoDto;
-import rastle.dev.rastle_backend.domain.member.model.Address;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.domain.member.model.Member;
 import rastle.dev.rastle_backend.domain.member.repository.mysql.MemberRepository;
 import rastle.dev.rastle_backend.global.error.exception.NotFoundByIdException;
@@ -73,26 +73,26 @@ public class MemberService {
     }
 
     /**
-     * 주소지 조회
-     * 
-     * @param memberId
-     */
-
-    @Transactional
-    public Address getMemberAddress(Long memberId) {
-        return memberRepository.findAddressById(memberId).orElseThrow(NotFoundByIdException::new);
-    }
-
-    /**
-     * 주소지 갱신
+     * 배송지 정보 갱신
      * 
      * @param memberId
      * @param newAddress
      */
     @Transactional
-    public void updateMemberAddress(Long memberId, Address newAddress) {
+    public void updateMemberRecipientInfo(Long memberId, RecipientInfo recipientInfo) {
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundByIdException::new);
-        member.updateAddress(newAddress);
+        member.updateRecipientInfo(recipientInfo);
+    }
+
+    /**
+     * 배송지 정보 조회
+     * 
+     * @param memberId
+     */
+
+    @Transactional
+    public RecipientInfo getMemberRecipientInfo(Long memberId) {
+        return memberRepository.findRecipientInfoById(memberId).orElseThrow(NotFoundByIdException::new);
     }
 
     /**

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/dto/MemberDTO.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/dto/MemberDTO.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import rastle.dev.rastle_backend.domain.member.model.Authority;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.domain.member.model.UserLoginType;
 
 public class MemberDTO {
@@ -59,8 +60,8 @@ public class MemberDTO {
         private String userName;
         @Schema(description = "전화번호", type = "string", format = "phone", example = "01012345678", required = true)
         private String phoneNumber;
-        @Schema(description = "주소", type = "string", format = "address", example = "서울시 강남구 어딘가로")
-        private String address;
+        @Schema(description = "배송지 정보", type = "object", format = "recipientInfo")
+        private RecipientInfo recipientInfo;
         @Schema(description = "생성 일시", type = "string", format = "createdDate", example = "2021-08-01T00:00:00")
         private LocalDateTime createdDate;
         @Schema(description = "주문 정보", type = "list", format = "orderDetails")

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/model/Member.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/model/Member.java
@@ -23,18 +23,9 @@ public class Member extends MemberBase {
     @Column(name = "phone_number")
     private String phoneNumber;
 
-    // @Column(name = "zip_code")
-    // private String zipCode;
-
-    // @Column(name = "road_address")
-    // private String roadAddress;
-
-    // @Column(name = "detail_address")
-    // private String detailAddress;
-
-    @Convert(converter = Address.AddressConverter.class)
-    @Column(name = "address", columnDefinition = "JSON")
-    private Address address;
+    @Convert(converter = RecipientInfo.AddressConverter.class)
+    @Column(name = "recipient_info", columnDefinition = "JSON")
+    private RecipientInfo recipientInfo;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Coupon> coupons = new ArrayList<>();
@@ -60,23 +51,11 @@ public class Member extends MemberBase {
         super.updatePassword(newPassword);
     }
 
-    public void updateAddress(Address newAddress) {
-        this.address = newAddress;
+    public void updateRecipientInfo(RecipientInfo newRecipientInfo) {
+        this.recipientInfo = newRecipientInfo;
     }
 
     public void updatePhoneNumber(String newPhoneNumber) {
         this.phoneNumber = newPhoneNumber;
     }
-
-    // public void updateZipcode(String newZipcode) {
-    // this.zipCode = newZipcode;
-    // }
-
-    // public void updateRoadAddress(String newRoadAddress) {
-    // this.roadAddress = newRoadAddress;
-    // }
-
-    // public void updateDetailAddress(String newDetailAddress) {
-    // this.detailAddress = newDetailAddress;
-    // }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/model/RecipientInfo.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/model/RecipientInfo.java
@@ -13,17 +13,20 @@ import rastle.dev.rastle_backend.global.converter.JsonConverter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "회원 주소")
-public class Address {
+@Schema(description = "배송지 정보")
+public class RecipientInfo {
+    @Schema(description = "받는 분 이름", defaultValue = "홍길동")
+    private String recipientName;
     @Schema(description = "우편번호", defaultValue = "12345")
     private String zipCode;
     @Schema(description = "도로명 주소", defaultValue = "서울특별시 강남구 테헤란로 427")
     private String roadAddress;
     @Schema(description = "상세 주소", defaultValue = "테헤란로 427")
     private String detailAddress;
+    @Schema(description = "받는 분 연락처", defaultValue = "01012345678")
+    private String recipientPhoneNumber;
 
-    public static class AddressConverter extends JsonConverter<Address> {
-
+    public static class AddressConverter extends JsonConverter<RecipientInfo> {
     }
 
     @Override
@@ -32,14 +35,20 @@ public class Address {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        Address address = (Address) o;
+        RecipientInfo address = (RecipientInfo) o;
         return Objects.equals(zipCode, address.zipCode) &&
                 Objects.equals(roadAddress, address.roadAddress) &&
-                Objects.equals(detailAddress, address.detailAddress);
+                Objects.equals(detailAddress, address.detailAddress)
+                && Objects.equals(recipientName, address.recipientName)
+                && Objects.equals(recipientPhoneNumber, address.recipientPhoneNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(zipCode, roadAddress, detailAddress);
+        return Objects.hash(recipientName, zipCode, roadAddress, detailAddress, recipientPhoneNumber);
+    }
+
+    public void updateRecipientInfoName(String recipientName) {
+        this.recipientName = recipientName;
     }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.LoginMemberInfoDto;
-import rastle.dev.rastle_backend.domain.member.model.Address;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.domain.member.model.Member;
 
 import java.util.Optional;
@@ -21,6 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m FROM Member m WHERE m.authority = 'ROLE_USER'")
     Page<Member> findAllUsers(Pageable pageable);
 
-    @Query("SELECT m.address FROM Member m WHERE m.id = :id")
-    Optional<Address> findAddressById(@Param("id") Long id);
+    @Query("SELECT m.recipientInfo FROM Member m WHERE m.id = :id")
+    Optional<RecipientInfo> findRecipientInfoById(@Param("id") Long id);
 }

--- a/src/main/java/rastle/dev/rastle_backend/global/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/rastle/dev/rastle_backend/global/oauth2/application/CustomOAuth2UserService.java
@@ -14,6 +14,7 @@ import rastle.dev.rastle_backend.domain.coupon.model.Coupon;
 import rastle.dev.rastle_backend.domain.coupon.repository.mysql.CouponRepository;
 import rastle.dev.rastle_backend.domain.member.model.Authority;
 import rastle.dev.rastle_backend.domain.member.model.Member;
+import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 import rastle.dev.rastle_backend.domain.member.model.UserLoginType;
 import rastle.dev.rastle_backend.domain.member.model.UserPrincipal;
 import rastle.dev.rastle_backend.domain.member.repository.mysql.MemberRepository;
@@ -54,10 +55,18 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                                 .userLoginType(loginType)
                                 .authority(Authority.ROLE_USER)
                                 .build();
+
+                RecipientInfo recipientInfo = new RecipientInfo();
+                recipientInfo.setRecipientName(memberInfo.getName());
+                recipientInfo.setRecipientPhoneNumber(memberInfo.getPhoneNumber());
+                member.updateRecipientInfo(recipientInfo);
+
                 Cart build = Cart.builder().member(member).build();
                 cartRepository.save(build);
+
                 Coupon coupon = Coupon.builder().discount(3000).name("회원가입 축하 쿠폰").member(member).build();
                 couponRepository.save(coupon);
+
                 return memberRepository.save(member);
         }
 }

--- a/src/main/java/rastle/dev/rastle_backend/global/oauth2/provider/KakaoOAuth2UserInfo.java
+++ b/src/main/java/rastle/dev/rastle_backend/global/oauth2/provider/KakaoOAuth2UserInfo.java
@@ -19,31 +19,27 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getName() {
-        // Map<String, Object> properties = (Map<String, Object>)
-        // attributes.get("properties");
         Map<String, Object> properties = (Map<String, Object>) attributes.get("kakao_account");
-
         if (properties == null) {
             return null;
         }
 
-        return (String) properties.get("nickname");
+        return (String) properties.get("name");
     }
 
     @Override
     public String getEmail() {
         Map<String, Object> properties = (Map<String, Object>) attributes.get("kakao_account");
-
         if (properties == null) {
             return null;
         }
+
         return (String) properties.get("email");
     }
 
     @Override
     public String getPhoneNumber() {
         Map<String, Object> properties = (Map<String, Object>) attributes.get("kakao_account");
-
         if (properties == null) {
             return null;
         }


### PR DESCRIPTION
회원 주소지가 배송지 정보로 변경됨에 따라 아래 내용이 변경되었습니다.
- Member.java의 Address 클래스를 RecipientInfo 클래스로 변경
- MemberRepository.java의 Address 클래스를 RecipientInfo 클래스로 변경
- MemberService.java의 Address 클래스를 RecipientInfo 클래스로 변경
- MemberAuthService.java의 Address 클래스를 RecipientInfo 클래스로 변경
- MemberController.java의 Address 클래스를 RecipientInfo 클래스로 변경
- AdminService.java의 Address 클래스를 RecipientInfo 클래스로 변경
- CustomOAuth2UserService.java의 Address 클래스를 RecipientInfo 클래스로 변경

처음 홈페이지 회원가입 및 소셜 로그인 시 입력받는 이름과 연락처가 배송지 정보로 초기 설정됩니다.