### PR TITLE
refactor: MemberRepository 쿼리 최적화

### DIFF
--- a/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberAuthService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberAuthService.java
@@ -92,7 +92,7 @@ public class MemberAuthService {
      */
     @Transactional
     public boolean isEmailDuplicated(String email) {
-        return memberRepository.findByEmail(email).isPresent();
+        return memberRepository.findUserIdByEmail(email).isPresent();
     }
 
     /**
@@ -117,11 +117,11 @@ public class MemberAuthService {
     private HttpHeaders createAuthorizationHeader(HttpServletRequest request, String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
-//        if (request.getHeader("Origin") == null) {
-//            headers.set("Access-Control-Allow-Origin", "https://recordyslow.com");
-//        } else {
-//            headers.set("Access-Control-Allow-Origin", request.getHeader("Origin"));
-//        }
+        // if (request.getHeader("Origin") == null) {
+        // headers.set("Access-Control-Allow-Origin", "https://recordyslow.com");
+        // } else {
+        // headers.set("Access-Control-Allow-Origin", request.getHeader("Origin"));
+        // }
         return headers;
     }
 
@@ -150,14 +150,14 @@ public class MemberAuthService {
 
     private void deleteRefreshTokenCookie(HttpServletResponse response) {
         ResponseCookie cookie = ResponseCookie.from("refreshToken", null)
-            .maxAge(0)
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            // .domain("recordyslow.com")
-            // .sameSite("Strict")
-            .sameSite("None")
-            .build();
+                .maxAge(0)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                // .domain("recordyslow.com")
+                // .sameSite("Strict")
+                .sameSite("None")
+                .build();
 
         response.addHeader("Set-Cookie", cookie.toString());
     }

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/application/MemberService.java
@@ -29,7 +29,7 @@ public class MemberService {
      */
     @Transactional
     public LoginMemberInfoDto getLoginMemberInfo(Long memberId) {
-        return memberRepository.findMemberInfoById(memberId).orElseThrow(NotFoundByIdException::new);
+        return memberRepository.findLoginMemberInfoById(memberId).orElseThrow(NotFoundByIdException::new);
     }
 
     /**
@@ -41,9 +41,11 @@ public class MemberService {
      */
     @Transactional
     public void changePassword(Long memberId, String newPassword) {
-        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundByIdException::new);
-        String encodedPassword = passwordEncoder.encode(newPassword);
-        member.updatePassword(encodedPassword);
+        // Member member =
+        // memberRepository.findById(memberId).orElseThrow(NotFoundByIdException::new);
+        // String encodedPassword = passwordEncoder.encode(newPassword);
+        // member.updatePassword(encodedPassword);
+        memberRepository.updatePassword(memberId, passwordEncoder.encode(newPassword));
     }
 
     /**
@@ -58,13 +60,13 @@ public class MemberService {
 
         redisTemplate.delete(username);
         ResponseCookie cookie = ResponseCookie.from("refreshToken", null)
-            .maxAge(0)
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            .domain("recordyslow.com")
-            .sameSite("Strict")
-            .build();
+                .maxAge(0)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .domain("recordyslow.com")
+                .sameSite("Strict")
+                .build();
 
         response.addHeader("Set-Cookie", cookie.toString());
         memberRepository.delete(member);

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/dto/MemberAuthDTO.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/dto/MemberAuthDTO.java
@@ -49,13 +49,13 @@ public class MemberAuthDTO {
 
         public Member toEntity() {
             return Member.builder()
-                .email(email)
-                .password(password)
-                .userLoginType(UserLoginType.EMAIL)
-                .authority(Authority.ROLE_USER)
-                .phoneNumber(phoneNumber)
-                .userName(username)
-                .build();
+                    .email(email)
+                    .password(password)
+                    .userLoginType(UserLoginType.EMAIL)
+                    .authority(Authority.ROLE_USER)
+                    .phoneNumber(phoneNumber)
+                    .userName(username)
+                    .build();
         }
     }
 
@@ -135,5 +135,17 @@ public class MemberAuthDTO {
     public static class PasswordResetRequestDto {
         @Schema(description = "비밀번호 초기화 요청 이메일", type = "string", format = "email", example = "example@email.com", required = true)
         private String email;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Schema(description = "인증된 유저 정보 요청 DTO")
+    public static class UserPrincipalInfoDto {
+        private Long id;
+        private String password;
+        private UserLoginType userLoginType;
+        private Authority authority;
     }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/model/Member.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/model/Member.java
@@ -41,15 +41,15 @@ public class Member extends MemberBase {
 
     @Builder
     public Member(String email, String password, UserLoginType userLoginType, Authority authority, String userName,
-                  String phoneNumber) {
+            String phoneNumber) {
         super(email, password, userLoginType, authority);
         this.userName = userName;
         this.phoneNumber = phoneNumber;
     }
 
-    public void updatePassword(String newPassword) {
-        super.updatePassword(newPassword);
-    }
+    // public void updatePassword(String newPassword) {
+    // super.updatePassword(newPassword);
+    // }
 
     public void updateRecipientInfo(RecipientInfo newRecipientInfo) {
         this.recipientInfo = newRecipientInfo;

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/model/MemberBase.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/model/MemberBase.java
@@ -46,7 +46,7 @@ public class MemberBase {
         this.authority = authority;
     }
 
-    public void updatePassword(String newPassword) {
-        this.password = newPassword;
-    }
+    // public void updatePassword(String newPassword) {
+    // this.password = newPassword;
+    // }
 }

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/model/UserPrincipal.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/model/UserPrincipal.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.UserPrincipalInfoDto;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -84,12 +86,20 @@ public class UserPrincipal implements UserDetails, OidcUser {
 
     public static UserPrincipal create(Member member) {
         return new UserPrincipal(
-            String.valueOf(member.getId()),
-            member.getPassword(),
-            member.getUserLoginType(),
-            member.getAuthority(),
-            Collections.singletonList(new SimpleGrantedAuthority(member.getAuthority().toString())));
+                String.valueOf(member.getId()),
+                member.getPassword(),
+                member.getUserLoginType(),
+                member.getAuthority(),
+                Collections.singletonList(new SimpleGrantedAuthority(member.getAuthority().toString())));
+    }
 
+    public static UserPrincipal create(UserPrincipalInfoDto userPrincipalInfoDto) {
+        return new UserPrincipal(
+                String.valueOf(userPrincipalInfoDto.getId()),
+                userPrincipalInfoDto.getPassword(),
+                userPrincipalInfoDto.getUserLoginType(),
+                userPrincipalInfoDto.getAuthority(),
+                Collections.singletonList(new SimpleGrantedAuthority(userPrincipalInfoDto.getAuthority().toString())));
     }
 
     public static UserPrincipal create(Member user, Map<String, Object> attributes) {

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
@@ -3,19 +3,38 @@ package rastle.dev.rastle_backend.domain.member.repository.mysql;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.UserPrincipalInfoDto;
 import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.LoginMemberInfoDto;
+import rastle.dev.rastle_backend.domain.member.dto.MemberDTO.MemberInfoDto;
 import rastle.dev.rastle_backend.domain.member.model.Member;
 import rastle.dev.rastle_backend.domain.member.model.RecipientInfo;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("SELECT m.id FROM Member m WHERE m.email = :email")
+    Optional<Long> findUserIdByEmail(@Param("email") String email);
+
+    @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO$UserPrincipalInfoDto(m.id, m.password, m.userLoginType, m.authority) FROM Member m WHERE m.email = :email")
+    Optional<UserPrincipalInfoDto> findUserPrincipalInfoByEmail(@Param("email") String email);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.password = :newPassword WHERE m.id = :memberId")
+    void updatePassword(@Param("memberId") Long memberId, @Param("newPassword") String newPassword);
+
+    @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberDTO$MemberInfoDto(" +
+            "m.email, m.userLoginType, m.userName, m.phoneNumber, m.recipientInfo, m.createdDate) " +
+            "FROM Member m WHERE m.id = :id")
+    MemberInfoDto findMemberInfoById(@Param("id") Long id);
+
     Optional<Member> findByEmail(String email);
 
     @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberDTO$LoginMemberInfoDto(m.email, m.userName, m.phoneNumber, m.userLoginType, m.authority) FROM Member m WHERE m.id = :id")
-    Optional<LoginMemberInfoDto> findMemberInfoById(@Param("id") Long id);
+    Optional<LoginMemberInfoDto> findLoginMemberInfoById(@Param("id") Long id);
 
     @Query("SELECT m FROM Member m WHERE m.authority = 'ROLE_USER'")
     Page<Member> findAllUsers(Pageable pageable);

--- a/src/main/java/rastle/dev/rastle_backend/domain/order/application/OrderService.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/order/application/OrderService.java
@@ -49,7 +49,7 @@ public class OrderService {
     @Transactional
     public OrderCreateResponse createOrderDetail(Long memberId, OrderCreateRequest orderCreateRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(NotFoundByIdException::new);
-        if (!(member.getId() == 11L || member.getId() == 8L || member.getId() == 9L)) {
+        if (!(member.getId() == 11L || member.getId() == 8L || member.getId() == 92L)) {
             throw new NotAuthorizedException();
         }
         OrderDetail orderDetail = OrderDetail.builder()

--- a/src/main/java/rastle/dev/rastle_backend/global/filter/JwtFilter.java
+++ b/src/main/java/rastle/dev/rastle_backend/global/filter/JwtFilter.java
@@ -32,7 +32,7 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
+        log.info(request.getMethod() + " " + request.getRequestURI());
         try {
             String jwt = resolveToken(request);
             if (jwt != null) {

--- a/src/main/java/rastle/dev/rastle_backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/rastle/dev/rastle_backend/global/security/CustomUserDetailsService.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.UserPrincipalInfoDto;
 import rastle.dev.rastle_backend.domain.member.model.Member;
 import rastle.dev.rastle_backend.domain.member.model.UserPrincipal;
 import rastle.dev.rastle_backend.domain.member.repository.mysql.MemberRepository;
@@ -19,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Optional<Member> byEmail = memberRepository.findByEmail(username);
+        Optional<UserPrincipalInfoDto> byEmail = memberRepository.findUserPrincipalInfoByEmail(username);
         if (byEmail.isPresent()) {
             return UserPrincipal.create(byEmail.get());
         } else {


### PR DESCRIPTION
findByEmail 메서드의 쿼리를 여러개로 나누었습니다.
- findUserIdByEmail
- findUserPrincipalInfoByEmail

findById 메서드의 쿼리를 여러개로 나누었습니다.
-findMemberInfoById
-findLoginMemberInfoById

updatePassword 쿼리를 추가하였습니다.