### PR TITLE
refactor: 리프레시 토큰 재발급 최적화

### DIFF
--- a/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
@@ -22,6 +22,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO$UserPrincipalInfoDto(m.id, m.password, m.userLoginType, m.authority) FROM Member m WHERE m.email = :email")
     Optional<UserPrincipalInfoDto> findUserPrincipalInfoByEmail(@Param("email") String email);
 
+    @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO$UserPrincipalInfoDto(m.id, m.password, m.userLoginType, m.authority) FROM Member m WHERE m.id = :id")
+    Optional<UserPrincipalInfoDto> findUserPrincipalInfoById(@Param("email") Long id);
+
     @Modifying
     @Query("UPDATE Member m SET m.password = :newPassword WHERE m.id = :memberId")
     void updatePassword(@Param("memberId") Long memberId, @Param("newPassword") String newPassword);

--- a/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
+++ b/src/main/java/rastle/dev/rastle_backend/domain/member/repository/mysql/MemberRepository.java
@@ -23,7 +23,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<UserPrincipalInfoDto> findUserPrincipalInfoByEmail(@Param("email") String email);
 
     @Query("SELECT NEW rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO$UserPrincipalInfoDto(m.id, m.password, m.userLoginType, m.authority) FROM Member m WHERE m.id = :id")
-    Optional<UserPrincipalInfoDto> findUserPrincipalInfoById(@Param("email") Long id);
+    Optional<UserPrincipalInfoDto> findUserPrincipalInfoById(@Param("id") Long id);
 
     @Modifying
     @Query("UPDATE Member m SET m.password = :newPassword WHERE m.id = :memberId")

--- a/src/main/java/rastle/dev/rastle_backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/rastle/dev/rastle_backend/global/security/CustomUserDetailsService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import rastle.dev.rastle_backend.domain.member.dto.MemberAuthDTO.UserPrincipalInfoDto;
-import rastle.dev.rastle_backend.domain.member.model.Member;
 import rastle.dev.rastle_backend.domain.member.model.UserPrincipal;
 import rastle.dev.rastle_backend.domain.member.repository.mysql.MemberRepository;
 
@@ -30,7 +29,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     public UserDetails loadUserById(String userIdString) {
         Long userId = Long.parseLong(userIdString);
-        Optional<Member> byId = memberRepository.findById(userId);
+        Optional<UserPrincipalInfoDto> byId = memberRepository.findUserPrincipalInfoById(userId);
         if (byId.isPresent()) {
             return UserPrincipal.create(byId.get());
         } else {


### PR DESCRIPTION

findById를 findUserPrincipalInfoById로 변경하여
리프레시 토큰 재발급 로직을 최적화하였습니다.